### PR TITLE
Move to newer Sphinx version and build approach

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,4 +25,6 @@ release = version = subprocess.check_output(
 
 html_theme = 'alabaster'
 
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,4 @@
-Sphinx==4.4.0
+Sphinx>5
 
-# Pins for contrib versions which supports the Sphinx version we have pinned:
-sphinxcontrib.applehelp<1.0.8
-sphinxcontrib.devhelp<1.0.6
-sphinxcontrib.htmlhelp<2.0.5
-sphinxcontrib.serializinghtml<1.1.10
-sphinxcontrib.qthelp<1.0.7
-
-# Semi-requirement, needed to run setup.py.
-# TODO: move to standalone docs build.
+# Neeeded for setup.py
 setuptools

--- a/script/docs/build.sh
+++ b/script/docs/build.sh
@@ -2,4 +2,4 @@
 
 cd $(dirname $(dirname  $(dirname $0)))
 
-exec python setup.py build_sphinx "$@"
+exec sphinx-build -M html docs build/sphinx/ "$@"

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,5 @@ setup(
         'Typing :: Typed',
     ],
     python_requires='>=3.7',
-    setup_requires=[
-        'Sphinx >=1.8.5, <5',
-    ],
     zip_safe=True,
 )


### PR DESCRIPTION
This should enable support for newer Python versions too, where Sphinx 4.x is no longer supported. There are some small changes in the render of the docs, mostly improvements and nothing concerning.